### PR TITLE
fix: 修复部分回放无法播放的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 
 #Electron-builder output
 /dist_electron
+

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "element-ui": "^2.12.0",
     "fluent-ffmpeg": "^2.1.2",
     "flv.js": "^1.5.0",
+    "@types/lodash": "4.14.170",
     "lodash": "^4.17.21",
     "lowdb": "^1.0.0",
     "update-electron-app": "^2.0.1",
     "video.js": "^7.15.4",
-    "vue": "^2.6.10",
+    "vue": "2.6.14",
     "vue-class-component": "^7.0.2",
     "vue-property-decorator": "^8.1.0",
     "vue-router": "^3.1.3"
@@ -37,12 +38,12 @@
     "@vue/cli-plugin-typescript": "^3.11.0",
     "@vue/cli-service": "^3.11.0",
     "electron": "^9.4.0",
-    "node-sass": "^4.9.0",
-    "sass-loader": "^7.1.0",
+    "sass": "^1.32.0",
+    "sass-loader": "^10.0.0",
     "typescript": "^3.6.3",
     "vue-cli-plugin-electron-builder": "^1.4.0",
     "vue-cli-plugin-element": "^1.0.1",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "2.6.14"
   },
   "postcss": {
     "plugins": {
@@ -54,3 +55,4 @@
     "last 2 versions"
   ]
 }
+

--- a/src/background.ts
+++ b/src/background.ts
@@ -88,20 +88,8 @@ app.on('activate', () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', async () => {
-    if (isDevelopment && !process.env.IS_TEST) {
-        // Install Vue Devtools
-        // Devtools extensions are broken in Electron 6.0.0 and greater
-        // See https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/378 for more info
-        // Electron will not launch with Devtools extensions installed on Windows 10 with dark mode
-        // If you are not using Windows 10 dark mode, you may uncomment these lines
-        // In addition, if the linked issue is closed, you can upgrade electron and uncomment these lines
-        try {
-          await installVueDevtools()
-        } catch (e) {
-          console.error('Vue Devtools failed to install:', e.toString())
-        }
-
-    }
+    // Vue Devtools 在 Electron 6+ 和 Windows 10 暗色模式下有兼容问题，已禁用
+    // See https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/378
 
     const menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);

--- a/src/components/Review.vue
+++ b/src/components/Review.vue
@@ -194,16 +194,27 @@
         /**
          * 初始化VideoJS
          */
+        /**
+         * 初始化VideoJS
+         */
         protected initVideoJs() {
             const videoJsPlayer = VideoJs('video-js-' + this.liveId, {
                 autoplay: false, // 自动播放
                 controls: true, // 是否显示控制栏
                 techOrder: ['html5'], // 兼容顺序
-                sourceOrder: true, //
+                sourceOrder: true,
                 sources: [{
-                    src: this.playStreamPath
+                    src: this.playStreamPath,
+                    type: 'application/x-mpegURL' // HLS 流必须指定 MIME type
                 }],
-              playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4, 4.5, 5]
+                playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4, 4.5, 5],
+                html5: {
+                    vhs: {
+                        overrideNative: true // 强制使用 VHS 而非原生 HLS（Electron/Chromium 原生不支持 HLS）
+                    },
+                    nativeAudioTracks: false,
+                    nativeVideoTracks: false
+                }
             });
             this.player = new VideoJsPlayer(videoJsPlayer);
 
@@ -305,11 +316,11 @@
 </script>
 
 <style scoped lang="scss">
-/deep/.el-carousel__container {
+::v-deep .el-carousel__container {
   height: 100%;
 }
 
-/deep/.el-carousel__item {
+::v-deep .el-carousel__item {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "strict": true,
+    "skipLibCheck": true,
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
@@ -37,3 +38,4 @@
     "node_modules"
   ]
 }
+


### PR DESCRIPTION
- VideoJS 播放 HLS 流时添加 MIME type 和 VHS 配置
- 替换 node-sass 为 dart-sass 解决编译问题
- 锁定 Vue/lodash 类型定义版本避免 TS 冲突
- 禁用 Vue Devtools 修复 Electron 启动失败
- 修复 /deep/ 为 ::v-deep 兼容新版 Sass